### PR TITLE
Make training params ordering flexible

### DIFF
--- a/pypeako/peako.py
+++ b/pypeako/peako.py
@@ -915,7 +915,8 @@ class Peako(object):
 
         if self.tempfiles:
             self.write_temporary_files()
-        similarity_array = np.full([len(self.training_params[key]) for key in self.training_params.keys()], np.nan)
+        param_names = ('t_avg', 'h_avg', 'span', 'polyorder', 'width', 'prom')
+        similarity_array = np.full([len(self.training_params[key]) for key in param_names], np.nan)
         for i, t_avg in enumerate(self.training_params['t_avg']):
             for j, h_avg in enumerate(self.training_params['h_avg']):
                 if not self.tempfiles:
@@ -987,7 +988,8 @@ class Peako(object):
         if self.save_similarities:
             outfile_name = f'{self.plot_dir}{kwargs["filename_similarities"]}' if 'filename_similarities' in kwargs \
                 else f'{self.plot_dir}peako_similarities_k{self.current_k}.nc'
-            (xr.Dataset({'similarities': xr.DataArray(similarity_array, self.training_params)})).to_netcdf(
+            coords = { k: self.training_params[k] for k in param_names }
+            (xr.Dataset({'similarities': xr.DataArray(similarity_array, coords)})).to_netcdf(
                 path=outfile_name)
 
         # extract the three parameter combinations yielding the maximum similarity
@@ -1731,7 +1733,7 @@ class TrainingData(object):
 
         closeby = kwargs['closeby'] if 'closeby' in kwargs else np.repeat(None, len(self.spec_data))
         yRange = kwargs['yRange'] if 'yRange' in kwargs else np.repeat(None, len(self.spec_data))
-        
+
         for n in range(len(self.spec_data)):
             s = 0
             if closeby[n] is not None:
@@ -1952,7 +1954,7 @@ class TrainingData(object):
                     ax[1,1].scatter(event.xdata, event.ydata, color='black', zorder=2, marker='x')  # Mark the peak
                     self.all_markings[-1].append([event.xdata, event.ydata])  # Save the peak
                     fig.canvas.draw()  # Redraw the figure to update the plot
-        
+
 
             # Define callback for toggle button
             def ontoggle(change):
@@ -1965,7 +1967,7 @@ class TrainingData(object):
                 self.training_data_out[n_file][self.timeindex_center, self.heightindex_center, 0:len(xvals)] = xvals
                 self.plot_count[n_file] = len(self.all_markings)
                 self.all_markings.append([])
-                
+
                 # next spectrum...
                 self.heightindex_center = random.randint(r_range[0], r_range[1])
                 self.timeindex_center = random.randint(t_range[0], t_range[1])
@@ -1975,7 +1977,7 @@ class TrainingData(object):
                 self.fig, self.ax = ret
                 self.fig.canvas.draw()
                 self.fig.canvas.flush_events()
-                
+
             def onfinish(change):
                 for dim1 in range(3):
                     for dim2 in range(3):
@@ -2003,7 +2005,7 @@ class TrainingData(object):
                 pane_heights=[0, 6, 0.5]
             )
             return AL
-        
+
             vals = [point for marking in all_markings for point in marking]
             print(vals)
             return vals, peakPowers  # Return all marked peaks
@@ -2036,7 +2038,7 @@ class TrainingData(object):
         ax[1, 1].grid(True)
         ax[1, 1].legend()
         return fig, ax
-        
+
 
 
     def save_training_data(self):


### PR DESCRIPTION
Currently, the shape of the `similarity_array` depends on the order of the parameters in the `training_params` dictionary. When the ordering is not exactly like `t_avg`, `h_avg`, `span`, `polyorder`, `width`, `prom`, the shape will be wrong and there will be errors when training PEAKO. This pull request fixes this problem by hardcoding the `param_names`.